### PR TITLE
Fix/getViewArConfig

### DIFF
--- a/config/utils.js
+++ b/config/utils.js
@@ -18,7 +18,7 @@ const buildPath = path.join(root, 'build');
 
 const getViewARConfig = () => {
   try {
-    return JSON.parse(fs.readFileSync(`${__dirname}/../.viewar-config`));
+    return JSON.parse(fs.readFileSync(path.join(root, '.viewar-config')));
   } catch (e) {
     console.error(
       '[ViewAR] ERROR: File .viewar-config not existing or invalid JSON format.'

--- a/config/utils.js
+++ b/config/utils.js
@@ -1,3 +1,4 @@
+const fs = require('fs');
 const webpack = require('webpack');
 const path = require('path');
 const bodyParser = require('body-parser');


### PR DESCRIPTION
could not read `.viewar-config` file, because the "fs" module wasn't required.
which resulted in:  
`[ViewAR] ERROR: File .viewar-config not existing or invalid JSON format.`  
 

real error was surpressed by try-block
`ReferenceError: fs is not defined`